### PR TITLE
Fixed an issue where squeeze made the tensor dimension wrong

### DIFF
--- a/IVModule.py
+++ b/IVModule.py
@@ -165,8 +165,9 @@ class conv1x1(nn.Module):
         output = self.conv(feature)
         output = self.bn(output)
         output = self.avgpool(output)
-        output = output.squeeze()
- 
+        # output = output.squeeze()
+        bs, c, h, w = output.shape
+        output = torch.reshape(output, (bs, c * h * w))
         return output
         
 


### PR DESCRIPTION
Fixed dimension error during squeeze operation in 1x1 convolution #4 